### PR TITLE
Reuse table allocations for GraphicalTimer

### DIFF
--- a/Necrosis.lua
+++ b/Necrosis.lua
@@ -82,6 +82,30 @@ local SpellGroup = {
 	Visible = {true, true, true}
 };
 
+-- Clears contents but preserves subtable objects
+local function clear_tables(t)
+    for k, v in pairs(t) do
+        if type(v) == "table" then
+            -- recurse: empty the subtable
+            clear_tables(v)
+        else
+            -- remove only non-table values
+            t[k] = nil
+        end
+    end
+end
+
+
+-- Reusable buffers for graphical timers (avoid per-frame allocations)
+local GraphicalTimer = {
+  texte  = {},
+  TimeMax= {},
+  Time   = {},
+  titre  = {},
+  temps  = {},
+  Gtimer = {},
+}
+
 local TimerTable = {};
 for i = 1, 50, 1 do
 	TimerTable[i] = false;
@@ -473,54 +497,51 @@ function Necrosis_OnUpdate()
 	-- Parcours du tableau des Timers
 	if SpellTimer then
 		if update then
+			clear_tables(GraphicalTimer);
 			textTimersDisplay = "";
-			local GraphicalTimer = {texte = {}, TimeMax = {}, Time = {}, titre = {}, temps = {}, Gtimer = {}};
 			for index = 1, table.getn(SpellTimer), 1 do
 				if SpellTimer[index] then
 					if (GetTime() <= SpellTimer[index].TimeMax) then
 						-- Création de l'affichage des timers
 						textTimersDisplay, SpellGroup, GraphicalTimer, TimerTable = Necrosis_DisplayTimer(textTimersDisplay, index, SpellGroup, SpellTimer, GraphicalTimer, TimerTable);
 					end
-					-- Action toutes les secondes
-					if (update) then
-						-- On enlève les timers terminés
-						if curTime >= (SpellTimer[index].TimeMax - 0.5) and SpellTimer[index].TimeMax ~= -1 then
-							-- Si le timer était celui de la Pierre d'âme, on prévient le Démoniste
-							if SpellTimer[index].Name == NECROSIS_SPELL_TABLE[11].Name then
-								Necrosis_Msg(NECROSIS_MESSAGE.Information.SoulstoneEnd, "USER");
-								SpellTimer[index].Target = "";
-								SpellTimer[index].TimeMax = -1;
-								if NecrosisConfig.Sound then PlaySoundFile(NECROSIS_SOUND.SoulstoneEnd); end
-								Necrosis_RemoveFrame(SpellTimer[index].Gtimer, TimerTable);
-									-- On met à jour l'apparence du bouton de la pierre d'âme
-								Necrosis_UpdateIcons();
-							-- Sinon on enlève le timer silencieusement (mais pas en cas d'enslave)
-							elseif SpellTimer[index].Name ~= NECROSIS_SPELL_TABLE[10].Name then
+					-- On enlève les timers terminés
+					if curTime >= (SpellTimer[index].TimeMax - 0.5) and SpellTimer[index].TimeMax ~= -1 then
+						-- Si le timer était celui de la Pierre d'âme, on prévient le Démoniste
+						if SpellTimer[index].Name == NECROSIS_SPELL_TABLE[11].Name then
+							Necrosis_Msg(NECROSIS_MESSAGE.Information.SoulstoneEnd, "USER");
+							SpellTimer[index].Target = "";
+							SpellTimer[index].TimeMax = -1;
+							if NecrosisConfig.Sound then PlaySoundFile(NECROSIS_SOUND.SoulstoneEnd); end
+							Necrosis_RemoveFrame(SpellTimer[index].Gtimer, TimerTable);
+								-- On met à jour l'apparence du bouton de la pierre d'âme
+							Necrosis_UpdateIcons();
+						-- Sinon on enlève le timer silencieusement (mais pas en cas d'enslave)
+						elseif SpellTimer[index].Name ~= NECROSIS_SPELL_TABLE[10].Name then
+							SpellTimer, TimerTable = Necrosis_RetraitTimerParIndex(index, SpellTimer, TimerTable);
+							index = 0;
+							break;
+						end
+					end
+					-- Si le Démoniste n'est plus sous l'emprise du Sacrifice
+					if SpellTimer and SpellTimer[index].Name == NECROSIS_SPELL_TABLE[17].Name then -- Sacrifice
+						if not Necrosis_UnitHasEffect("player", SpellTimer[index].Name) and SpellTimer[index].TimeMax ~= nil then
+							SpellTimer, TimerTable = Necrosis_RetraitTimerParIndex(index, SpellTimer, TimerTable);
+							index = 0;
+							break;
+						end
+					end
+					-- Si la cible visée n'est plus atteinte par un sort lancé [résists]
+					if SpellTimer and (SpellTimer[index].Type == 4 or SpellTimer[index].Type == 5)
+						and SpellTimer[index].Target == UnitName("target")
+						then
+						-- On triche pour laisser le temps au mob de bien sentir qu'il est débuffé ^^
+						if curTime >= ((SpellTimer[index].TimeMax - SpellTimer[index].Time) + 1.5)
+							and SpellTimer[index] ~= 6 then
+							if not Necrosis_UnitHasEffect("target", SpellTimer[index].Name) then
 								SpellTimer, TimerTable = Necrosis_RetraitTimerParIndex(index, SpellTimer, TimerTable);
 								index = 0;
 								break;
-							end
-						end
-						-- Si le Démoniste n'est plus sous l'emprise du Sacrifice
-						if SpellTimer and SpellTimer[index].Name == NECROSIS_SPELL_TABLE[17].Name then -- Sacrifice
-							if not Necrosis_UnitHasEffect("player", SpellTimer[index].Name) and SpellTimer[index].TimeMax ~= nil then
-								SpellTimer, TimerTable = Necrosis_RetraitTimerParIndex(index, SpellTimer, TimerTable);
-								index = 0;
-								break;
-							end
-						end
-						-- Si la cible visée n'est plus atteinte par un sort lancé [résists]
-						if SpellTimer and (SpellTimer[index].Type == 4 or SpellTimer[index].Type == 5)
-							and SpellTimer[index].Target == UnitName("target")
-							then
-							-- On triche pour laisser le temps au mob de bien sentir qu'il est débuffé ^^
-							if curTime >= ((SpellTimer[index].TimeMax - SpellTimer[index].Time) + 1.5)
-								and SpellTimer[index] ~= 6 then
-								if not Necrosis_UnitHasEffect("target", SpellTimer[index].Name) then
-									SpellTimer, TimerTable = Necrosis_RetraitTimerParIndex(index, SpellTimer, TimerTable);
-									index = 0;
-									break;
-								end
 							end
 						end
 					end


### PR DESCRIPTION
Reuse table allocations for GraphicalTimer rather than creating new ones every update and relying on the garbage collector.

## Bug: Per-frame table allocation causing memory growth in OnUpdate

### Problem
In `Necrosis_OnUpdate` the addon was creating a brand-new `GraphicalTimer` table (and subtables) **every frame**.  At ~60 FPS this meant:

7 new tables per frame

420 tables per second

~25,000 tables per minute

This led to unbounded memory growth. Profiling showed:

2000 KB allocated at 60s

4368 KB allocated at 75s
→ ~2368 KB increase over 15s (~9 MB/minute).
<img width="502" height="146" alt="Before 1Min in" src="https://github.com/user-attachments/assets/b0a18395-0d03-4af3-af6e-c9001bc8ec30" />
<img width="698" height="173" alt="Before 1Min and 15s" src="https://github.com/user-attachments/assets/76a5ebf8-97f2-48a5-aa6c-27402cd1d766" />
With it climbing ever higher until a garbage collection cycle...
<img width="502" height="140" alt="Climbing" src="https://github.com/user-attachments/assets/a8abf73b-5052-4d1f-b6fd-7750c897a8de" />

This pull request introduces optimizations to timer management in `Necrosis.lua`, primarily by reducing per-frame memory allocations for graphical timer buffers and improving table clearing. The main changes focus on reusing preallocated tables and introducing a recursive table wipe function.

**Performance optimizations:**

* Added a `wipe_table` function to recursively clear table contents, ensuring all nested tables are emptied efficiently.
* Refactored graphical timer buffer allocation by introducing a reusable `GraphicalTimer` table, preventing per-frame allocations and improving performance.
* Updated the timer update logic in `Necrosis_OnUpdate()` to reuse the preallocated `GraphicalTimer` buffers, clearing them each frame with `wipe_table` instead of allocating new tables.

### Result
No longer have memory spiking and garbage collection causing frame/game freezes.  Necrosis memory stays relatively constant with a memory usage roughly ~99.9% lower after 5 minutes of game time.
<img width="502" height="380" alt="After" src="https://github.com/user-attachments/assets/95f3f07a-9d6f-4e0b-99e1-3deb56c62a0d" />

